### PR TITLE
Corrected LED GPIO pin referenced in the text

### DIFF
--- a/test-led-python.md
+++ b/test-led-python.md
@@ -20,7 +20,7 @@ With your circuit complete, you are now ready to write some code to switch the L
 
     GPIO.setup(led,GPIO.OUT)
     ```
-    The first two lines tells the Python interpreter (the thing that runs the Python code) that it will be using a ‘library’. You will need the `time` library in order to add timings to your program and the `RPi.GPIO` library that will tell the Pi how to work with the Raspberry Pi’s GPIO pins. A ‘library’ gives a programming language extra commands that can be used to do something different that it previously did not know how to do. This is like adding a new channel to your TV so you can watch something different. Each pin on the Pi has several different names, so you need to tell the program which naming convention is to be used in the third line of the code. The second to last line tells Python not to print GPIO warning messages to the screen. The final line tells Python to set up pin 18 as an output.
+    The first two lines tells the Python interpreter (the thing that runs the Python code) that it will be using a ‘library’. You will need the `time` library in order to add timings to your program and the `RPi.GPIO` library that will tell the Pi how to work with the Raspberry Pi’s GPIO pins. A ‘library’ gives a programming language extra commands that can be used to do something different that it previously did not know how to do. This is like adding a new channel to your TV so you can watch something different. Each pin on the Pi has several different names, so you need to tell the program which naming convention is to be used in the third line of the code. The second to last line tells Python not to print GPIO warning messages to the screen. The final line tells Python to set up pin 17 as an output.
 
 1. Underneath the code you have just entered, type:
 
@@ -30,7 +30,7 @@ With your circuit complete, you are now ready to write some code to switch the L
     ```
     The `print` function prints some information to the terminal. This is handy as it tells you what is happening, so that even if you LED doesn't come on you know that your program is working. If that happens then there might be something wrong with the wiring of your circuit and you should go back through the steps above to check.
 
-    The next line turns the GPIO pin 18 ‘on’. What this actually means is that this pin is made to provide power of 3.3 volts. This is enough to turn the LED in your circuit on.
+    The next line turns the GPIO pin 17 ‘on’. What this actually means is that this pin is made to provide power of 3.3 volts. This is enough to turn the LED in your circuit on.
 
 1. The code so far will turn on the LED; let's add some code to turn it off after a period of time. Below your existing code, type:
 
@@ -39,7 +39,7 @@ With your circuit complete, you are now ready to write some code to switch the L
     print("Light off")
     GPIO.output(led,GPIO.LOW)
     ```
-    The first line adds a pause or sleep. It tells the program to sleep for one second before moving onto the next line in the sequence of code. During this time your LED will be on because you have not told it to do anything else yet. To turn the LED off, you add a line similar to the one that turned GPIO pin 18 on, instead you replace GPIO.HIGH with GPIO.LOW. This will turn the pin off so that it no longer supplies any voltage.
+    The first line adds a pause or sleep. It tells the program to sleep for one second before moving onto the next line in the sequence of code. During this time your LED will be on because you have not told it to do anything else yet. To turn the LED off, you add a line similar to the one that turned GPIO pin 17 on, instead you replace GPIO.HIGH with GPIO.LOW. This will turn the pin off so that it no longer supplies any voltage.
 
 1. The final part to add to your program is:
 


### PR DESCRIPTION
The python code uses GPIO BCM pin 17 but the text referenced pin 18.  Left the code as pin 17 (and corrected the text) as the corresponding Scratch example also uses pin 17.
